### PR TITLE
Fix bug where max range of minutes or hours was returning one less value

### DIFF
--- a/src/CronExpressionParser.Core/Fields/Field.cs
+++ b/src/CronExpressionParser.Core/Fields/Field.cs
@@ -38,7 +38,7 @@ namespace CronExpressionParser.Core.Fields
 			if (valuesSplitByDash.Length > 1)
 			{
 				var parsedIntegersSplitByDash = TryParseIntegers(valuesSplitByDash).ToList();
-				return new List<int>(Enumerable.Range(parsedIntegersSplitByDash[0], parsedIntegersSplitByDash[1]));
+				return parsedIntegersSplitByDash[0].GetIncrementsOf(1, parsedIntegersSplitByDash[1]).ToList();
 			}
 
 			var valuesSplitBySlash = minutesExpression.Split(Constants.IncrementsChar);

--- a/src/CronExpressionParser.Core/Properties/launchSettings.json
+++ b/src/CronExpressionParser.Core/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "CronExpressionParser.Core": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "*/15 0 1,15 * 1-5 /usr/bin/find"
     }
   }
 }

--- a/src/CronExpressionParser.UnitTests/HoursFieldShould.cs
+++ b/src/CronExpressionParser.UnitTests/HoursFieldShould.cs
@@ -13,7 +13,7 @@ namespace CronExpressionParser.UnitTests
 		private static readonly TestCaseData[] HappyPathTestCases =
 		{
 			new TestCaseData("1", new List<int> { 1 }).SetName("SingleValueExpression"),
-			new TestCaseData("*", new List<int>(Enumerable.Range(0, 23))).SetName("SingleStarExpression"),
+			new TestCaseData("*", new List<int>(Enumerable.Range(0, 24))).SetName("SingleStarExpression"),
 			new TestCaseData("1, 2, 3", new List<int> { 1, 2, 3 }).SetName("AdditionalValuesExpression"),
 			new TestCaseData("1-5", new List<int> { 1, 2, 3, 4, 5 }).SetName("RangeExpression"),
 			new TestCaseData("*/10", new List<int> { 0, 10, 20 }).SetName("IncrementsFromStarExpression"),

--- a/src/CronExpressionParser.UnitTests/MinutesFieldShould.cs
+++ b/src/CronExpressionParser.UnitTests/MinutesFieldShould.cs
@@ -13,7 +13,7 @@ namespace CronExpressionParser.UnitTests
 		private static readonly TestCaseData[] HappyPathTestCases =
 		{
 			new TestCaseData("1", new List<int> { 1 }).SetName("SingleValueExpression"),
-			new TestCaseData("*", new List<int>(Enumerable.Range(0, 59))).SetName("SingleStarExpression"),
+			new TestCaseData("*", new List<int>(Enumerable.Range(0, 60))).SetName("SingleStarExpression"),
 			new TestCaseData("1, 2, 3", new List<int> { 1, 2, 3 }).SetName("AdditionalValuesExpression"),
 			new TestCaseData("1-5", new List<int> { 1, 2, 3, 4, 5 }).SetName("RangeExpression"),
 			new TestCaseData("*/10", new List<int> { 0, 10, 20, 30, 40, 50 }).SetName("IncrementsFromStarExpression"),


### PR DESCRIPTION
Implementation and tests were relying on same logic for Enumerable.Range() but since the second param is count and not max value, the method was returning one less value for minutes and hours, since these two fields start at value 0.